### PR TITLE
Rename site from Crafty Code to Aigenc.ie

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,6 +1,6 @@
-baseURL = 'https://craftycode.org/'
+baseURL = 'https://aigenc.ie/'
 languageCode = 'en-GB'
-title = 'Crafty Code'
+title = 'Aigenc.ie'
 content = 'content/'
 theme = 'craftytheme'
 

--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,6 +1,6 @@
-baseURL = 'https://craftycode.org/'
+baseURL = 'https://aigenc.ie/'
 languageCode = 'en-GB'
-title = 'Crafty Code'
+title = 'Aigenc.ie'
 content = 'content/'
 
 [services]

--- a/content/da/about.md
+++ b/content/da/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Om Crafty Code"
+title = "Om Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code udforsker krydsfeltet mellem softwareudvikling og forretning i EU med fokus på bæredygtighed, lederskab og reel indflydelse. Bloggen er skrevet af Jeff, en erfaren softwareingeniør og forretningsstrateg, og dækker teknologitendenser, forretningsstrategi og praktiske indsigter for startups og iværksættere."
+description = "Aigenc.ie udforsker krydsfeltet mellem softwareudvikling og forretning i EU med fokus på bæredygtighed, lederskab og reel indflydelse. Bloggen er skrevet af Jeff, en erfaren softwareingeniør og forretningsstrateg, og dækker teknologitendenser, forretningsstrategi og praktiske indsigter for startups og iværksættere."
 keywords = [
     "softwareudvikling",
     "EU-forretning",
@@ -28,17 +28,17 @@ tags = [
     "iværksætteri",
     "software engineering",
 ]
-summary = "Hos Crafty Code er målet at forbinde softwareudviklingens verden med dens plads i den virkelige verden.\n\nSelvom der allerede findes et hav af indhold med fokus på USA, vil Crafty Code rette blikket mod EU’s softwareudviklings- og forretningslandskab."
-og_title = "Crafty Code: Udforskning af softwareudvikling, forretning og bæredygtighed i EU"
-og_description = "Dyk ned i Crafty Code for indsigter om softwareudvikling, forretningsstrategi, bæredygtighed og teknologitendenser i EU. Bloggen ledes af Jeff, en erfaren softwareingeniør og strateg, og forbinder tech med reel indflydelse i verden."
+summary = "Hos Aigenc.ie er målet at forbinde softwareudviklingens verden med dens plads i den virkelige verden.\n\nSelvom der allerede findes et hav af indhold med fokus på USA, vil Aigenc.ie rette blikket mod EU’s softwareudviklings- og forretningslandskab."
+og_title = "Aigenc.ie: Udforskning af softwareudvikling, forretning og bæredygtighed i EU"
+og_description = "Dyk ned i Aigenc.ie for indsigter om softwareudvikling, forretningsstrategi, bæredygtighed og teknologitendenser i EU. Bloggen ledes af Jeff, en erfaren softwareingeniør og strateg, og forbinder tech med reel indflydelse i verden."
 translated = true
 original_language = "en"
 translated_to = "danish"
 +++
 
-Hos Crafty Code er målet at forbinde softwareudviklingens verden med dens plads i den virkelige verden.
+Hos Aigenc.ie er målet at forbinde softwareudviklingens verden med dens plads i den virkelige verden.
 
-Selvom der allerede findes masser af indhold med fokus på USA, vil Crafty Code fokusere på EU’s softwareudviklings- og forretningslandskab.
+Selvom der allerede findes masser af indhold med fokus på USA, vil Aigenc.ie fokusere på EU’s softwareudviklings- og forretningslandskab.
 
 ## Mit navn er Jeff
 

--- a/content/de/about.md
+++ b/content/de/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Über Crafty Code"
+title = "Über Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code untersucht die Schnittstelle zwischen Softwareentwicklung und Business in der EU, mit einem Fokus auf Nachhaltigkeit, Leadership und echten Auswirkungen. Geschrieben von Jeff, einem erfahrenen Software Engineer und Business Strategen, behandelt der Blog Technologietrends, Geschäftsstrategien und praxisnahe Einblicke für Startups und Unternehmer:innen."
+description = "Aigenc.ie untersucht die Schnittstelle zwischen Softwareentwicklung und Business in der EU, mit einem Fokus auf Nachhaltigkeit, Leadership und echten Auswirkungen. Geschrieben von Jeff, einem erfahrenen Software Engineer und Business Strategen, behandelt der Blog Technologietrends, Geschäftsstrategien und praxisnahe Einblicke für Startups und Unternehmer:innen."
 keywords = [
     "Softwareentwicklung",
     "EU-Geschäft",
@@ -28,17 +28,17 @@ tags = [
     "Entrepreneurship",
     "Software Engineering",
 ]
-summary = "Bei Crafty Code geht es darum, die Welt der Softwareentwicklung mit ihrem Platz in der realen Welt zu verbinden.\n\nWährend es bereits eine Fülle von Inhalten mit Fokus auf die USA gibt, wird sich Crafty Code auf die Softwareentwicklung und die Geschäftswelt in der EU konzentrieren."
-og_title = "Crafty Code: Einblicke in Softwareentwicklung, Business und Nachhaltigkeit in der EU"
-og_description = "Tauche ein in Crafty Code für Einblicke in Softwareentwicklung, Geschäftsstrategie, Nachhaltigkeit und Technologietrends in der EU. Geleitet von Jeff, einem erfahrenen Software Engineer und Strategen, verbindet dieser Blog Technologie mit echtem Einfluss auf die Welt."
+summary = "Bei Aigenc.ie geht es darum, die Welt der Softwareentwicklung mit ihrem Platz in der realen Welt zu verbinden.\n\nWährend es bereits eine Fülle von Inhalten mit Fokus auf die USA gibt, wird sich Aigenc.ie auf die Softwareentwicklung und die Geschäftswelt in der EU konzentrieren."
+og_title = "Aigenc.ie: Einblicke in Softwareentwicklung, Business und Nachhaltigkeit in der EU"
+og_description = "Tauche ein in Aigenc.ie für Einblicke in Softwareentwicklung, Geschäftsstrategie, Nachhaltigkeit und Technologietrends in der EU. Geleitet von Jeff, einem erfahrenen Software Engineer und Strategen, verbindet dieser Blog Technologie mit echtem Einfluss auf die Welt."
 translated = true
 original_language = "en"
 translated_to = "german"
 +++
 
-Bei Crafty Code geht es darum, die Welt der Softwareentwicklung mit ihrem Platz in der realen Welt zu verbinden.
+Bei Aigenc.ie geht es darum, die Welt der Softwareentwicklung mit ihrem Platz in der realen Welt zu verbinden.
 
-Während es bereits eine Fülle von Inhalten mit Fokus auf die USA gibt, konzentriert sich Crafty Code auf die europäische Softwareentwicklungs- und Geschäftswelt.
+Während es bereits eine Fülle von Inhalten mit Fokus auf die USA gibt, konzentriert sich Aigenc.ie auf die europäische Softwareentwicklungs- und Geschäftswelt.
 
 ## Mein Name ist Jeff
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Home"
-description: "Crafty Code explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact."
+description: "Aigenc.ie explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact."
 ---

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -1,9 +1,9 @@
 +++
-title = "About Crafty Code"
+title = "About Aigenc.ie"
 date = 2024-07-09T21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact. Written by Jeff, an experienced software engineer and business strategist, the blog covers technology trends, business strategy, and practical insights for startups and entrepreneurs."
+description = "Aigenc.ie explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact. Written by Jeff, an experienced software engineer and business strategist, the blog covers technology trends, business strategy, and practical insights for startups and entrepreneurs."
 keywords = [
     "software development",
     "EU business",
@@ -28,13 +28,13 @@ tags = [
     "entrepreneurship",
     "software engineering",
 ]
-summary = "At Crafty Code, the aim is to link the world of Software Development to its place in the real world.\n\nWhile there's already a wealth of content focused on the US, Crafty Code will focus on the EU's software development and business landscape."
+summary = "At Aigenc.ie, the aim is to link the world of Software Development to its place in the real world.\n\nWhile there's already a wealth of content focused on the US, Aigenc.ie will focus on the EU's software development and business landscape."
 +++
 
-Crafty Code explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact.
+Aigenc.ie explores the intersection of software development and business in the EU, with a focus on sustainability, leadership, and real-world impact.
 
 Written by Jeff, an experienced software engineer and business strategist, the blog covers technology trends, business strategy, and practical insights for startups and entrepreneurs.
 
-At Crafty Code, the aim is to link the world of Software Development to its place in the real world.
+At Aigenc.ie, the aim is to link the world of Software Development to its place in the real world.
 
-While there's already a wealth of content focused on the US, Crafty Code will focus on the EU's software development and business landscape.
+While there's already a wealth of content focused on the US, Aigenc.ie will focus on the EU's software development and business landscape.

--- a/content/es/about.md
+++ b/content/es/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Acerca de Crafty Code"
+title = "Acerca de Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code explora la intersección entre el desarrollo de software y los negocios en la UE, con un enfoque en sostenibilidad, liderazgo e impacto real. Escrito por Jeff, un ingeniero de software y estratega de negocios con experiencia, el blog cubre tendencias tecnológicas, estrategia empresarial y consejos prácticos para startups y emprendedores."
+description = "Aigenc.ie explora la intersección entre el desarrollo de software y los negocios en la UE, con un enfoque en sostenibilidad, liderazgo e impacto real. Escrito por Jeff, un ingeniero de software y estratega de negocios con experiencia, el blog cubre tendencias tecnológicas, estrategia empresarial y consejos prácticos para startups y emprendedores."
 keywords = [
     "desarrollo de software",
     "Negocio en la UE",
@@ -28,17 +28,17 @@ tags = [
     "emprendimiento",
     "ingeniería de software",
 ]
-summary = "En Crafty Code, el objetivo es conectar el mundo del desarrollo de software con su lugar en el mundo real.\n\nAunque ya existe una gran cantidad de contenido enfocado en Estados Unidos, Crafty Code se centrará en el panorama del desarrollo de software y los negocios en la Unión Europea."
-og_title = "Crafty Code: Explorando el desarrollo de software, negocios y sostenibilidad en la UE"
-og_description = "Sumérgete en Crafty Code para descubrir ideas sobre desarrollo de software, estrategia empresarial, sostenibilidad y tendencias tecnológicas en la UE. Dirigido por Jeff, un ingeniero de software y estratega con experiencia, este blog conecta la tecnología con el impacto en el mundo real."
+summary = "En Aigenc.ie, el objetivo es conectar el mundo del desarrollo de software con su lugar en el mundo real.\n\nAunque ya existe una gran cantidad de contenido enfocado en Estados Unidos, Aigenc.ie se centrará en el panorama del desarrollo de software y los negocios en la Unión Europea."
+og_title = "Aigenc.ie: Explorando el desarrollo de software, negocios y sostenibilidad en la UE"
+og_description = "Sumérgete en Aigenc.ie para descubrir ideas sobre desarrollo de software, estrategia empresarial, sostenibilidad y tendencias tecnológicas en la UE. Dirigido por Jeff, un ingeniero de software y estratega con experiencia, este blog conecta la tecnología con el impacto en el mundo real."
 translated = true
 original_language = "en"
 translated_to = "spanish"
 +++
 
-En Crafty Code, el objetivo es conectar el mundo del Desarrollo de Software con su lugar en el mundo real.
+En Aigenc.ie, el objetivo es conectar el mundo del Desarrollo de Software con su lugar en el mundo real.
 
-Aunque ya existe una gran cantidad de contenido enfocado en EE. UU., Crafty Code se centrará en el panorama del desarrollo de software y los negocios en la UE.
+Aunque ya existe una gran cantidad de contenido enfocado en EE. UU., Aigenc.ie se centrará en el panorama del desarrollo de software y los negocios en la UE.
 
 ## Mi nombre es Jeff
 

--- a/content/fi/about.md
+++ b/content/fi/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Tietoa Crafty Codesta"
+title = "Tietoa Aigenc.iesta"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code tutkii ohjelmistokehityksen ja liiketoiminnan risteyskohtaa EU:ssa, painottaen kestävyyttä, johtajuutta ja todellista vaikuttavuutta. Blogia kirjoittaa Jeff, kokenut ohjelmistoinsinööri ja liiketoimintastrategi. Blogissa käsitellään teknologiatrendejä, liiketoimintastrategiaa sekä käytännön oivalluksia startupeille ja yrittäjille."
+description = "Aigenc.ie tutkii ohjelmistokehityksen ja liiketoiminnan risteyskohtaa EU:ssa, painottaen kestävyyttä, johtajuutta ja todellista vaikuttavuutta. Blogia kirjoittaa Jeff, kokenut ohjelmistoinsinööri ja liiketoimintastrategi. Blogissa käsitellään teknologiatrendejä, liiketoimintastrategiaa sekä käytännön oivalluksia startupeille ja yrittäjille."
 keywords = [
     "ohjelmistokehitys",
     "EU-liiketoiminta",
@@ -28,17 +28,17 @@ tags = [
     "yrittäjyys",
     "ohjelmistoinsinöörityö",
 ]
-summary = "Crafty Codella tavoitteena on yhdistää ohjelmistokehityksen maailma sen todelliseen rooliin arjessa.\n\nVaikka Yhdysvaltoihin keskittyvää sisältöä on jo runsaasti, Crafty Code keskittyy EU:n ohjelmistokehityksen ja liiketoiminnan kenttään."
+summary = "Aigenc.iella tavoitteena on yhdistää ohjelmistokehityksen maailma sen todelliseen rooliin arjessa.\n\nVaikka Yhdysvaltoihin keskittyvää sisältöä on jo runsaasti, Aigenc.ie keskittyy EU:n ohjelmistokehityksen ja liiketoiminnan kenttään."
 og_title = "Kekseliästä koodia: EU:n ohjelmistokehityksen, liiketoiminnan ja kestävyyden tutkimusmatka"
-og_description = "Sukella Crafty Codeen saadaksesi näkemyksiä ohjelmistokehityksestä, liiketoimintastrategiasta, kestävyydestä ja teknologiatrendeistä EU:ssa. Blogia vetää Jeff, kokenut ohjelmistoinsinööri ja strategisti, joka yhdistää teknologian ja todellisen maailman vaikutukset."
+og_description = "Sukella Aigenc.ieen saadaksesi näkemyksiä ohjelmistokehityksestä, liiketoimintastrategiasta, kestävyydestä ja teknologiatrendeistä EU:ssa. Blogia vetää Jeff, kokenut ohjelmistoinsinööri ja strategisti, joka yhdistää teknologian ja todellisen maailman vaikutukset."
 translated = true
 original_language = "en"
 translated_to = "finnish"
 +++
 
-Crafty Codessa tavoitteena on yhdistää ohjelmistokehityksen maailma sen paikkaan oikeassa elämässä.
+Aigenc.iessa tavoitteena on yhdistää ohjelmistokehityksen maailma sen paikkaan oikeassa elämässä.
 
-Vaikka Yhdysvaltoihin keskittyvää sisältöä on jo paljon, Crafty Code keskittyy EU:n ohjelmistokehityksen ja liiketoiminnan kenttään.
+Vaikka Yhdysvaltoihin keskittyvää sisältöä on jo paljon, Aigenc.ie keskittyy EU:n ohjelmistokehityksen ja liiketoiminnan kenttään.
 
 ## Nimeni on Jeff
 

--- a/content/fr/about.md
+++ b/content/fr/about.md
@@ -1,9 +1,9 @@
 +++
-title = "À propos de Crafty Code"
+title = "À propos de Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code explore l’intersection entre le développement logiciel et le business en Europe, avec un accent sur la durabilité, le leadership et l’impact concret. Rédigé par Jeff, ingénieur logiciel chevronné et stratège d’entreprise, le blog couvre les tendances technologiques, la stratégie business et des conseils pratiques pour les startups et les entrepreneurs."
+description = "Aigenc.ie explore l’intersection entre le développement logiciel et le business en Europe, avec un accent sur la durabilité, le leadership et l’impact concret. Rédigé par Jeff, ingénieur logiciel chevronné et stratège d’entreprise, le blog couvre les tendances technologiques, la stratégie business et des conseils pratiques pour les startups et les entrepreneurs."
 keywords = [
     "développement logiciel",
     "Affaires européennes",
@@ -28,17 +28,17 @@ tags = [
     "entrepreneuriat",
     "ingénierie logicielle",
 ]
-summary = "Chez Crafty Code, l'objectif est de relier le monde du développement logiciel à sa place dans le monde réel.\n\nAlors qu'il existe déjà une multitude de contenus axés sur les États-Unis, Crafty Code se concentrera sur le paysage européen du développement logiciel et des affaires."
-og_title = "Crafty Code : Explorer le développement logiciel, le business et la durabilité en Europe"
-og_description = "Plongez dans Crafty Code pour des analyses sur le développement logiciel, la stratégie d’entreprise, la durabilité et les tendances technologiques en Europe. Animé par Jeff, ingénieur logiciel et stratège chevronné, ce blog relie la tech à l’impact concret dans le monde réel."
+summary = "Chez Aigenc.ie, l'objectif est de relier le monde du développement logiciel à sa place dans le monde réel.\n\nAlors qu'il existe déjà une multitude de contenus axés sur les États-Unis, Aigenc.ie se concentrera sur le paysage européen du développement logiciel et des affaires."
+og_title = "Aigenc.ie : Explorer le développement logiciel, le business et la durabilité en Europe"
+og_description = "Plongez dans Aigenc.ie pour des analyses sur le développement logiciel, la stratégie d’entreprise, la durabilité et les tendances technologiques en Europe. Animé par Jeff, ingénieur logiciel et stratège chevronné, ce blog relie la tech à l’impact concret dans le monde réel."
 translated = true
 original_language = "en"
 translated_to = "french"
 +++
 
-Chez Crafty Code, l’objectif est de relier le monde du développement logiciel à sa place dans le monde réel.
+Chez Aigenc.ie, l’objectif est de relier le monde du développement logiciel à sa place dans le monde réel.
 
-Alors qu’il existe déjà une multitude de contenus axés sur les États-Unis, Crafty Code va se concentrer sur le paysage européen du développement logiciel et du business.
+Alors qu’il existe déjà une multitude de contenus axés sur les États-Unis, Aigenc.ie va se concentrer sur le paysage européen du développement logiciel et du business.
 
 ## Je m’appelle Jeff
 

--- a/content/ie/about.md
+++ b/content/ie/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Maidir le Crafty Code"
+title = "Maidir le Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Scrúdaíonn Crafty Code an áit a dtagann forbairt bogearraí agus gnó le chéile san AE, le béim ar inbhuanaitheacht, ceannaireacht, agus tionchar sa saol fíor. Scríofa ag Jeff, innealtóir bogearraí a bhfuil taithí aige agus straitéiseoir gnó, clúdaíonn an blag treochtaí teicneolaíochta, straitéis ghnó, agus léargais phraiticiúla do ghnólachtaí nuathionscanta agus fiontraithe."
+description = "Scrúdaíonn Aigenc.ie an áit a dtagann forbairt bogearraí agus gnó le chéile san AE, le béim ar inbhuanaitheacht, ceannaireacht, agus tionchar sa saol fíor. Scríofa ag Jeff, innealtóir bogearraí a bhfuil taithí aige agus straitéiseoir gnó, clúdaíonn an blag treochtaí teicneolaíochta, straitéis ghnó, agus léargais phraiticiúla do ghnólachtaí nuathionscanta agus fiontraithe."
 keywords = [
     "forbairt bogearraí",
     "Gnó an AE",
@@ -28,17 +28,17 @@ tags = [
     "fiontraíocht",
     "innealtóireacht bogearraí",
 ]
-summary = "Ag Crafty Code, is é an sprioc ná an domhan Forbartha Bogearraí a nascadh lena áit sa bhfíorshaol.\n\nCé go bhfuil neart ábhar ann cheana féin atá dírithe ar na Stáit Aontaithe, beidh Crafty Code ag díriú ar thírdhreach forbartha bogearraí agus gnó an AE."
-og_title = "Crafty Code: Ag Iniúchadh Forbairt Bogearraí, Gnó, agus Inbhuanaitheacht san AE"
-og_description = "Téigh i dtaithí ar Crafty Code le haghaidh léargais ar fhorbairt bogearraí, straitéis ghnó, inbhuanaitheacht, agus treochtaí teicneolaíochta san AE. Faoi stiúir Jeff, innealtóir bogearraí agus straitéiseoir a bhfuil taithí aige, nascann an blag seo an teicneolaíocht le tionchar sa saol fíor."
+summary = "Ag Aigenc.ie, is é an sprioc ná an domhan Forbartha Bogearraí a nascadh lena áit sa bhfíorshaol.\n\nCé go bhfuil neart ábhar ann cheana féin atá dírithe ar na Stáit Aontaithe, beidh Aigenc.ie ag díriú ar thírdhreach forbartha bogearraí agus gnó an AE."
+og_title = "Aigenc.ie: Ag Iniúchadh Forbairt Bogearraí, Gnó, agus Inbhuanaitheacht san AE"
+og_description = "Téigh i dtaithí ar Aigenc.ie le haghaidh léargais ar fhorbairt bogearraí, straitéis ghnó, inbhuanaitheacht, agus treochtaí teicneolaíochta san AE. Faoi stiúir Jeff, innealtóir bogearraí agus straitéiseoir a bhfuil taithí aige, nascann an blag seo an teicneolaíocht le tionchar sa saol fíor."
 translated = true
 original_language = "en"
 translated_to = "irish"
 +++
 
-Ag Crafty Code, is é an aidhm ná nasc a chruthú idir domhan na Forbartha Bogearraí agus a áit sa saol fíor.
+Ag Aigenc.ie, is é an aidhm ná nasc a chruthú idir domhan na Forbartha Bogearraí agus a áit sa saol fíor.
 
-Cé go bhfuil neart ábhar ann cheana féin atá dírithe ar SAM, beidh Crafty Code ag díriú ar thírdhreach forbartha bogearraí agus gnó an AE.
+Cé go bhfuil neart ábhar ann cheana féin atá dírithe ar SAM, beidh Aigenc.ie ag díriú ar thírdhreach forbartha bogearraí agus gnó an AE.
 
 ## Is é Jeff an t-ainm atá orm
 

--- a/content/it/about.md
+++ b/content/it/about.md
@@ -1,9 +1,9 @@
 +++
-title = "## Informazioni su Crafty Code"
+title = "## Informazioni su Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code esplora l’intersezione tra sviluppo software e business nell’UE, con un focus su sostenibilità, leadership e impatto concreto. Scritto da Jeff, un esperto software engineer e business strategist, il blog tratta di trend tecnologici, strategie di business e spunti pratici per startup e imprenditori."
+description = "Aigenc.ie esplora l’intersezione tra sviluppo software e business nell’UE, con un focus su sostenibilità, leadership e impatto concreto. Scritto da Jeff, un esperto software engineer e business strategist, il blog tratta di trend tecnologici, strategie di business e spunti pratici per startup e imprenditori."
 keywords = [
     "sviluppo software",
     "Business UE",
@@ -28,17 +28,17 @@ tags = [
     "imprenditorialità",
     "ingegneria del software",
 ]
-summary = "Da Crafty Code, l'obiettivo è collegare il mondo dello Sviluppo Software al suo ruolo nel mondo reale.\n\nAnche se esiste già una grande quantità di contenuti focalizzati sugli Stati Uniti, Crafty Code si concentrerà sul panorama europeo dello sviluppo software e del business."
-og_title = "Crafty Code: Esplorare lo sviluppo software, il business e la sostenibilità nell’UE"
-og_description = "Immergiti in Crafty Code per scoprire approfondimenti su sviluppo software, strategia aziendale, sostenibilità e trend tecnologici nell’UE. Guidato da Jeff, un esperto software engineer e strategist, questo blog collega la tecnologia all’impatto concreto nel mondo reale."
+summary = "Da Aigenc.ie, l'obiettivo è collegare il mondo dello Sviluppo Software al suo ruolo nel mondo reale.\n\nAnche se esiste già una grande quantità di contenuti focalizzati sugli Stati Uniti, Aigenc.ie si concentrerà sul panorama europeo dello sviluppo software e del business."
+og_title = "Aigenc.ie: Esplorare lo sviluppo software, il business e la sostenibilità nell’UE"
+og_description = "Immergiti in Aigenc.ie per scoprire approfondimenti su sviluppo software, strategia aziendale, sostenibilità e trend tecnologici nell’UE. Guidato da Jeff, un esperto software engineer e strategist, questo blog collega la tecnologia all’impatto concreto nel mondo reale."
 translated = true
 original_language = "en"
 translated_to = "italian"
 +++
 
-Da Crafty Code, l’obiettivo è collegare il mondo dello Sviluppo Software al suo posto nel mondo reale.
+Da Aigenc.ie, l’obiettivo è collegare il mondo dello Sviluppo Software al suo posto nel mondo reale.
 
-Anche se esiste già una marea di contenuti focalizzati sugli Stati Uniti, Crafty Code si concentrerà sul panorama europeo dello sviluppo software e del business.
+Anche se esiste già una marea di contenuti focalizzati sugli Stati Uniti, Aigenc.ie si concentrerà sul panorama europeo dello sviluppo software e del business.
 
 ## Mi chiamo Jeff
 

--- a/content/nl/about.md
+++ b/content/nl/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Over Crafty Code"
+title = "Over Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code verkent het snijvlak van softwareontwikkeling en business in de EU, met een focus op duurzaamheid, leiderschap en echte impact. Geschreven door Jeff, een ervaren software engineer en business strateeg, behandelt de blog technologische trends, businessstrategie en praktische inzichten voor startups en ondernemers."
+description = "Aigenc.ie verkent het snijvlak van softwareontwikkeling en business in de EU, met een focus op duurzaamheid, leiderschap en echte impact. Geschreven door Jeff, een ervaren software engineer en business strateeg, behandelt de blog technologische trends, businessstrategie en praktische inzichten voor startups en ondernemers."
 keywords = [
     "softwareontwikkeling",
     "EU-business",
@@ -28,17 +28,17 @@ tags = [
     "ondernemerschap",
     "software engineering",
 ]
-summary = "Bij Crafty Code is het doel om de wereld van Software Development te verbinden met zijn plek in de echte wereld.\n\nHoewel er al een overvloed aan content is die zich richt op de VS, zal Crafty Code zich richten op het software development- en zakelijke landschap van de EU."
-og_title = "Crafty Code: Een verkenning van softwareontwikkeling, business en duurzaamheid in de EU"
-og_description = "Duik in Crafty Code voor inzichten over softwareontwikkeling, bedrijfsstrategie, duurzaamheid en technologische trends in de EU. Onder leiding van Jeff, een ervaren software engineer en strateeg, verbindt deze blog technologie met echte impact."
+summary = "Bij Aigenc.ie is het doel om de wereld van Software Development te verbinden met zijn plek in de echte wereld.\n\nHoewel er al een overvloed aan content is die zich richt op de VS, zal Aigenc.ie zich richten op het software development- en zakelijke landschap van de EU."
+og_title = "Aigenc.ie: Een verkenning van softwareontwikkeling, business en duurzaamheid in de EU"
+og_description = "Duik in Aigenc.ie voor inzichten over softwareontwikkeling, bedrijfsstrategie, duurzaamheid en technologische trends in de EU. Onder leiding van Jeff, een ervaren software engineer en strateeg, verbindt deze blog technologie met echte impact."
 translated = true
 original_language = "en"
 translated_to = "dutch"
 +++
 
-Bij Crafty Code is het doel om de wereld van Software Development te verbinden met zijn plek in de echte wereld.
+Bij Aigenc.ie is het doel om de wereld van Software Development te verbinden met zijn plek in de echte wereld.
 
-Hoewel er al veel content is die zich richt op de VS, zal Crafty Code zich focussen op het software development- en zakelijke landschap van de EU.
+Hoewel er al veel content is die zich richt op de VS, zal Aigenc.ie zich focussen op het software development- en zakelijke landschap van de EU.
 
 ## Mijn naam is Jeff
 

--- a/content/no/about.md
+++ b/content/no/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Om Crafty Code"
+title = "Om Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code utforsker skjæringspunktet mellom programvareutvikling og forretning i EU, med fokus på bærekraft, lederskap og reell påvirkning. Skrevet av Jeff, en erfaren programvareingeniør og forretningsstrateg, dekker bloggen teknologitrender, forretningsstrategi og praktiske innsikter for startups og gründere."
+description = "Aigenc.ie utforsker skjæringspunktet mellom programvareutvikling og forretning i EU, med fokus på bærekraft, lederskap og reell påvirkning. Skrevet av Jeff, en erfaren programvareingeniør og forretningsstrateg, dekker bloggen teknologitrender, forretningsstrategi og praktiske innsikter for startups og gründere."
 keywords = [
     "programvareutvikling",
     "EU-virksomhet",
@@ -28,17 +28,17 @@ tags = [
     "entreprenørskap",
     "programvareteknikk",
 ]
-summary = "Hos Crafty Code er målet å koble sammen programvareutvikling med dens plass i den virkelige verden.\n\nSelv om det allerede finnes et hav av innhold med fokus på USA, vil Crafty Code rette blikket mot programvareutvikling og forretningslandskapet i EU."
-og_title = "Crafty Code: Utforsker programvareutvikling, forretning og bærekraft i EU"
-og_description = "Fordyp deg i Crafty Code for innsikt om programvareutvikling, forretningsstrategi, bærekraft og teknologitrender i EU. Bloggen ledes av Jeff, en erfaren programvareingeniør og strateg, og kobler teknologi med reell påvirkning i samfunnet."
+summary = "Hos Aigenc.ie er målet å koble sammen programvareutvikling med dens plass i den virkelige verden.\n\nSelv om det allerede finnes et hav av innhold med fokus på USA, vil Aigenc.ie rette blikket mot programvareutvikling og forretningslandskapet i EU."
+og_title = "Aigenc.ie: Utforsker programvareutvikling, forretning og bærekraft i EU"
+og_description = "Fordyp deg i Aigenc.ie for innsikt om programvareutvikling, forretningsstrategi, bærekraft og teknologitrender i EU. Bloggen ledes av Jeff, en erfaren programvareingeniør og strateg, og kobler teknologi med reell påvirkning i samfunnet."
 translated = true
 original_language = "en"
 translated_to = "norwegian"
 +++
 
-Hos Crafty Code er målet å koble programvareutvikling til dens plass i den virkelige verden.
+Hos Aigenc.ie er målet å koble programvareutvikling til dens plass i den virkelige verden.
 
-Selv om det allerede finnes mye innhold med fokus på USA, vil Crafty Code rette blikket mot EU sitt landskap for programvareutvikling og næringsliv.
+Selv om det allerede finnes mye innhold med fokus på USA, vil Aigenc.ie rette blikket mot EU sitt landskap for programvareutvikling og næringsliv.
 
 ## Mitt navn er Jeff
 

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -1,9 +1,9 @@
 +++
-title = "Sobre o Crafty Code"
+title = "Sobre o Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code explora a interseção entre desenvolvimento de software e negócios na União Europeia, com foco em sustentabilidade, liderança e impacto real. Escrito por Jeff, um engenheiro de software experiente e estrategista de negócios, o blog aborda tendências de tecnologia, estratégia empresarial e insights práticos para startups e empreendedores."
+description = "Aigenc.ie explora a interseção entre desenvolvimento de software e negócios na União Europeia, com foco em sustentabilidade, liderança e impacto real. Escrito por Jeff, um engenheiro de software experiente e estrategista de negócios, o blog aborda tendências de tecnologia, estratégia empresarial e insights práticos para startups e empreendedores."
 keywords = [
     "desenvolvimento de software",
     "Negócios na UE",
@@ -28,17 +28,17 @@ tags = [
     "empreendedorismo",
     "engenharia de software",
 ]
-summary = "Na Crafty Code, o objetivo é conectar o mundo do Desenvolvimento de Software ao seu lugar no mundo real.\n\nEmbora já exista uma abundância de conteúdo focado nos EUA, a Crafty Code vai focar no cenário de desenvolvimento de software e negócios da UE."
-og_title = "Crafty Code: Explorando Desenvolvimento de Software, Negócios e Sustentabilidade na UE"
-og_description = "Mergulhe no Crafty Code para obter insights sobre desenvolvimento de software, estratégia de negócios, sustentabilidade e tendências tecnológicas na UE. Liderado por Jeff, um engenheiro de software e estrategista experiente, este blog conecta tecnologia com impacto no mundo real."
+summary = "Na Aigenc.ie, o objetivo é conectar o mundo do Desenvolvimento de Software ao seu lugar no mundo real.\n\nEmbora já exista uma abundância de conteúdo focado nos EUA, a Aigenc.ie vai focar no cenário de desenvolvimento de software e negócios da UE."
+og_title = "Aigenc.ie: Explorando Desenvolvimento de Software, Negócios e Sustentabilidade na UE"
+og_description = "Mergulhe no Aigenc.ie para obter insights sobre desenvolvimento de software, estratégia de negócios, sustentabilidade e tendências tecnológicas na UE. Liderado por Jeff, um engenheiro de software e estrategista experiente, este blog conecta tecnologia com impacto no mundo real."
 translated = true
 original_language = "en"
 translated_to = "portugese"
 +++
 
-Na Crafty Code, o objetivo é conectar o mundo do Desenvolvimento de Software ao seu lugar no mundo real.
+Na Aigenc.ie, o objetivo é conectar o mundo do Desenvolvimento de Software ao seu lugar no mundo real.
 
-Embora já exista uma infinidade de conteúdos focados nos EUA, a Crafty Code vai focar no cenário europeu de desenvolvimento de software e negócios.
+Embora já exista uma infinidade de conteúdos focados nos EUA, a Aigenc.ie vai focar no cenário europeu de desenvolvimento de software e negócios.
 
 ## Meu nome é Jeff
 

--- a/content/sv/about.md
+++ b/content/sv/about.md
@@ -1,9 +1,9 @@
 +++
-title = "## Om Crafty Code"
+title = "## Om Aigenc.ie"
 date = 2024-07-09 21:12:53+01:00
 draft = false
 type = "page"
-description = "Crafty Code utforskar skärningspunkten mellan mjukvaruutveckling och affärer inom EU, med fokus på hållbarhet, ledarskap och verklig påverkan. Bloggen, skriven av Jeff – en erfaren mjukvaruingenjör och affärsstrateg – täcker teknologitrender, affärsstrategi och praktiska insikter för startups och entreprenörer."
+description = "Aigenc.ie utforskar skärningspunkten mellan mjukvaruutveckling och affärer inom EU, med fokus på hållbarhet, ledarskap och verklig påverkan. Bloggen, skriven av Jeff – en erfaren mjukvaruingenjör och affärsstrateg – täcker teknologitrender, affärsstrategi och praktiska insikter för startups och entreprenörer."
 keywords = [
     "programvaruutveckling",
     "EU-verksamhet",
@@ -28,17 +28,17 @@ tags = [
     "entreprenörskap",
     "mjukvaruingenjörskap",
 ]
-summary = "På Crafty Code är målet att koppla samman mjukvaruutvecklingens värld med dess plats i verkligheten.\n\nÄven om det redan finns ett överflöd av innehåll med fokus på USA, kommer Crafty Code att fokusera på mjukvaruutveckling och affärslandskapet inom EU."
-og_title = "Crafty Code: Utforska mjukvaruutveckling, affärer och hållbarhet i EU"
-og_description = "Fördjupa dig i Crafty Code för insikter om mjukvaruutveckling, affärsstrategi, hållbarhet och teknologitrender inom EU. Bloggen leds av Jeff, en erfaren mjukvaruingenjör och strateg, och kopplar ihop teknik med verklig påverkan."
+summary = "På Aigenc.ie är målet att koppla samman mjukvaruutvecklingens värld med dess plats i verkligheten.\n\nÄven om det redan finns ett överflöd av innehåll med fokus på USA, kommer Aigenc.ie att fokusera på mjukvaruutveckling och affärslandskapet inom EU."
+og_title = "Aigenc.ie: Utforska mjukvaruutveckling, affärer och hållbarhet i EU"
+og_description = "Fördjupa dig i Aigenc.ie för insikter om mjukvaruutveckling, affärsstrategi, hållbarhet och teknologitrender inom EU. Bloggen leds av Jeff, en erfaren mjukvaruingenjör och strateg, och kopplar ihop teknik med verklig påverkan."
 translated = true
 original_language = "en"
 translated_to = "swedish"
 +++
 
-På Crafty Code är målet att koppla samman mjukvaruutvecklingens värld med dess plats i verkliga livet.
+På Aigenc.ie är målet att koppla samman mjukvaruutvecklingens värld med dess plats i verkliga livet.
 
-Även om det redan finns massor av innehåll med fokus på USA, kommer Crafty Code att fokusera på mjukvaruutveckling och affärslandskapet i EU.
+Även om det redan finns massor av innehåll med fokus på USA, kommer Aigenc.ie att fokusera på mjukvaruutveckling och affärslandskapet i EU.
 
 ## Mitt namn är Jeff
 


### PR DESCRIPTION
## Summary

- Updates Hugo config `title` to `Aigenc.ie` and `baseURL` to `https://aigenc.ie/` in both default and production configs
- Replaces all "Crafty Code" references with "Aigenc.ie" across all 12 language `about.md` files (en, de, es, fr, it, nl, pt, sv, da, fi, no, ie)
- Updates the English homepage `_index.md` description

## Test plan

- [ ] Build the site locally and confirm the title shows "Aigenc.ie" in the header and footer
- [ ] Check the About page in multiple languages renders the new name correctly
- [ ] Verify Open Graph meta tags (`og:site_name`) reflect the new name
- [ ] Confirm the baseURL resolves correctly once DNS is pointed to aigenc.ie

https://claude.ai/code/session_017sMGWCAJ3JPkFN8p2QP25G

---
_Generated by [Claude Code](https://claude.ai/code/session_017sMGWCAJ3JPkFN8p2QP25G)_